### PR TITLE
Enable Webpack 4 compatibility

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,2 @@
+// TODO: Drop Webpack 4 support; delete this file.
+export * from './lib/index.js';

--- a/lib/filters/clean_class/definition.js
+++ b/lib/filters/clean_class/definition.js
@@ -126,9 +126,7 @@ function cleanCssIdentifier(identifier, filter) {
  *
  * @param {Object<string, ?string|Object<string, ?string>>} state
  *   The shared configuration state object.
- * @param {Object<string, ?string|Object<string, ?string>>} config
- *   The Drupal config to save.
  */
-export function configInit(state, config) {
-  state.cleanClassCache = config.clean_class ?? {};
+export function configInit(state) {
+  state.cleanClassCache = {};
 }

--- a/package.json
+++ b/package.json
@@ -73,9 +73,7 @@
   "c8": {
     "all": true,
     "include": [
-      "lib",
-      "twig.js",
-      "twing.js"
+      "lib"
     ],
     "check-coverage": true,
     "statements": 100,

--- a/twig.js
+++ b/twig.js
@@ -1,0 +1,2 @@
+// TODO: Drop Webpack 4 support; delete this file.
+export * from './lib/twig.js';

--- a/twing.js
+++ b/twing.js
@@ -1,0 +1,2 @@
+// TODO: Drop Webpack 4 support; delete this file.
+export * from './lib/twing.js';


### PR DESCRIPTION
After we converted to pure ES Modules, Webpack 4 wasn't able to read the
"exports" entry in package.json or understand nullish coalescing operators (??).

Fixes #37